### PR TITLE
hotfix: cannot read first_name of undefined error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minskylab/medusa-payment-mercadopago",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Mercadopago Payment Provider for Medusa Commerce",
   "author": "Minsky Community <hello@minsky.cc>",
   "license": "MIT",

--- a/src/services/mercadopago.ts
+++ b/src/services/mercadopago.ts
@@ -106,8 +106,8 @@ class MercadopagoProviderService extends AbstractPaymentService {
     const preference = {
       items: items /**REQUIRED */,
       payer: {
-        name: cart.billing_address.first_name,
-        surname: cart.billing_address.last_name,
+        name: cart.billing_address?.first_name,
+        surname: cart.billing_address?.last_name,
         email: cart.email,
       },
       notification_url: `${this.options_.webhook_url}/mercadopago`,


### PR DESCRIPTION
# What does this PR do
- Add optional chaining to payer optional metadata
- Upgrade lib version to `0.0.5`

This fix is needed because in some cases, the first_name and last_name parameter does not exist in medusa payment sessions, and this is triggering an error: `Cannot ready properties first_name of undefined`